### PR TITLE
Preparations to publish plugin

### DIFF
--- a/ago/build.gradle
+++ b/ago/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id "java"
     id 'java-gradle-plugin'
+    id "com.gradle.plugin-publish" version "0.10.1"
     id "org.jetbrains.kotlin.jvm" version "1.3.31"
     id "maven-publish"
     id "signing"
@@ -12,7 +13,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 repositories {
-    mavenCentral()
+    jcenter()
 }
 
 apply from: "../ktlint.gradle"
@@ -36,15 +37,6 @@ compileTestKotlin {
     }
 }
 
-gradlePlugin {
-    plugins {
-        agoPlugin {
-            id = 'se.eelde.ago'
-            implementationClass = 'se.eelde.ago.AgoPlugin'
-        }
-    }
-}
-
 task javadocJar(type: Jar, dependsOn: javadoc) {
     archiveClassifier.set("javadoc")
 
@@ -60,6 +52,33 @@ artifacts {
     archives jar
     archives sourceJar
     archives javadocJar
+}
+
+// Use java-gradle-plugin to generate plugin descriptors and specify plugin ids
+gradlePlugin {
+    plugins {
+        agoPlugin {
+            id = 'se.eelde.ago'
+            implementationClass = 'se.eelde.ago.AgoPlugin'
+        }
+    }
+}
+
+// The configuration example below shows the minimum required properties
+// configured to publish your plugin to the plugin portal
+pluginBundle {
+    website = 'http://www.eelde.se/'
+    vcsUrl = 'https://github.com/erikeelde/android-gradle-optimization'
+    description = 'A plugin that verifies that optimizations are enabled on development machines.'
+    tags = ['optimization']
+
+    plugins {
+        agoPlugin {
+            // id is captured from java-gradle-plugin configuration
+            displayName = 'Gradle optimizations plugin'
+            version = '0.1'
+        }
+    }
 }
 
 publishing {

--- a/ago/build.gradle
+++ b/ago/build.gradle
@@ -2,12 +2,12 @@ plugins {
     id "java"
     id 'java-gradle-plugin'
     id "com.gradle.plugin-publish" version "0.10.1"
-    id "org.jetbrains.kotlin.jvm" version "1.3.31"
+    id "org.jetbrains.kotlin.jvm" version "1.3.50"
     id "maven-publish"
     id "signing"
 }
 
-version "unspecified"
+version "0.1-SNAPSHOT"
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
@@ -24,7 +24,7 @@ dependencies {
 
     testImplementation "junit:junit:4.12"
     testImplementation gradleTestKit()
-    testImplementation "com.google.truth:truth:0.44"
+    testImplementation "com.google.truth:truth:1.0"
 }
 compileKotlin {
     kotlinOptions {
@@ -59,7 +59,10 @@ gradlePlugin {
     plugins {
         agoPlugin {
             id = 'se.eelde.ago'
+            displayName = 'Make sure gradle is optimized'
+            description = 'Gradle plugin where you can configure optimizations that should be in place so that you will not run unoptimized gradle builds.'
             implementationClass = 'se.eelde.ago.AgoPlugin'
+
         }
     }
 }
@@ -86,7 +89,7 @@ publishing {
         jar(MavenPublication) {
             groupId = 'se.eelde'
             artifactId = project.name
-            version = 1 + "-SNAPSHOT"
+            version = "0.1-SNAPSHOT"
 
             from components.java
 

--- a/ago/src/main/java/se/eelde/ago/AgoOutputter.kt
+++ b/ago/src/main/java/se/eelde/ago/AgoOutputter.kt
@@ -13,10 +13,6 @@ class AgoOutputter(var logger: Logger, defaultProject: DefaultProject) {
     init {
         val styledTextOutputFactory = defaultProject.services.get(StyledTextOutputFactory::class.java)
         styledTextOutput = styledTextOutputFactory.create("ago")
-        styledTextOutput
-                .style(StyledTextOutput.Style.ProgressStatus).text("Eventually ")
-                .style(StyledTextOutput.Style.Failure).text("we will  ")
-                .style(StyledTextOutput.Style.Identifier).println("have teh color")
     }
 
     fun greatInfo() {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("com.github.ben-manes.versions") version "0.21.0"
+    id("com.github.ben-manes.versions") version "0.24.0"
 }
 
 buildscript {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Now is the time to decide on `apply plugin: 'se.eelde.ago'`. Do we want to drop the 'a' in 'ago'?